### PR TITLE
Fix verification of admin codes in user block modal

### DIFF
--- a/controllers/unlockController.js
+++ b/controllers/unlockController.js
@@ -2,6 +2,7 @@
 import dotenv from 'dotenv';
 import UnlockCode from '../models/UnlockCode.js';
 import Usuario from '../models/Usuario.js';
+import mongoose from 'mongoose';
 
 dotenv.config();
 
@@ -32,7 +33,7 @@ export const verifyUnlock = async (req, res) => {
       const underLimit = !dbCode.usageLimit || dbCode.usedCount < dbCode.usageLimit;
       if (withinFrom && withinUntil && underLimit) {
         await UnlockCode.updateOne({ _id: dbCode._id }, { $inc: { usedCount: 1 } });
-        if (usuarioId) {
+        if (usuarioId && mongoose.Types.ObjectId.isValid(usuarioId)) {
           await Usuario.findByIdAndUpdate(usuarioId, { bloqueado: false, descargasRealizadas: 0 });
         }
         return res.json({ ok: true, scope: dbCode.isMaster ? 'master' : 'user', resetDownloads: true });
@@ -42,7 +43,7 @@ export const verifyUnlock = async (req, res) => {
     // 2) Master codes from env (fallback)
     const masterCodes = parseEnvList(process.env.UNLOCK_MASTER_CODES);
     if (masterCodes.includes(codeUpper)) {
-      if (usuarioId) {
+      if (usuarioId && mongoose.Types.ObjectId.isValid(usuarioId)) {
         await Usuario.findByIdAndUpdate(usuarioId, { bloqueado: false, descargasRealizadas: 0 });
       }
       return res.json({ ok: true, scope: 'master', resetDownloads: true });
@@ -65,7 +66,7 @@ export const verifyUnlock = async (req, res) => {
     ]);
 
     if (validUserCodes.has(codeUpper)) {
-      if (usuarioId) {
+      if (usuarioId && mongoose.Types.ObjectId.isValid(usuarioId)) {
         await Usuario.findByIdAndUpdate(usuarioId, { bloqueado: false, descargasRealizadas: 0 });
       }
       return res.json({ ok: true, scope: 'user', resetDownloads: true });

--- a/frontend/src/views/VistaCompleta.vue
+++ b/frontend/src/views/VistaCompleta.vue
@@ -631,7 +631,18 @@ async function verificarCodigo() {
   
   try {
     const code = codigoDesbloqueo.value.trim();
-    const respuesta = await verifyUnlockCode({ code, usuarioId: usuarioId.value, nombre: nombre.value });
+    // Usar el ID real del usuario autenticado (MongoDB) si está disponible
+    let backendUsuarioId = null;
+    try {
+      const authUser = JSON.parse(localStorage.getItem('usuario') || '{}');
+      backendUsuarioId = authUser?.uid || null;
+    } catch {}
+
+    const respuesta = await verifyUnlockCode({
+      code,
+      usuarioId: backendUsuarioId,
+      nombre: nombre.value,
+    });
     if (respuesta?.ok && respuesta.resetDownloads) {
       descargasUsadas.value = 0;
       await guardarContadorUsuario();


### PR DESCRIPTION
Enable verification of admin-created unlock codes from the user lock modal by sending the correct user ID from the frontend and adding backend validation for it.

Previously, the frontend's lock modal sent a locally generated user ID instead of the authenticated user's MongoDB `_id`, preventing the backend from correctly identifying and unlocking the user. Additionally, the backend was updated to validate `usuarioId` as a valid MongoDB ObjectId before attempting to update the user, preventing potential server errors with invalid IDs.

---
<a href="https://cursor.com/background-agent?bcId=bc-aa9420ac-1255-4fbc-a5d3-18e9c16e180f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-aa9420ac-1255-4fbc-a5d3-18e9c16e180f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

